### PR TITLE
feat(seo): /r/{job_id} 网页 title 与面包屑加入检测模型

### DIFF
--- a/tests/test_seo_meta.py
+++ b/tests/test_seo_meta.py
@@ -1,0 +1,83 @@
+"""Tests for /r/{job_id} SEO meta — title diversity drives long-tail SEO,
+so model name must appear in the page title, not just domain + verdict.
+Without per-model variation, two reports on the same relay collide on the
+same title text and Google deduplicates them out of the index.
+"""
+
+from __future__ import annotations
+
+from web.server import _seo_meta_for_report
+
+
+def _base_report(**overrides):
+    """Minimal finished-report shape that _seo_meta_for_report consumes."""
+    report = {
+        "base_url": "https://www.fucheers.top/v1",
+        "protocol": "openai",
+        "target_model": "gpt-5.5",
+        "total_score": 91.0,
+        "verdict": "marginal",
+        "results": [
+            {"status": "pass"} for _ in range(7)
+        ] + [
+            {"status": "fail"} for _ in range(2)
+        ],
+    }
+    report.update(overrides)
+    return report
+
+
+def test_seo_title_includes_target_model():
+    """Each report's title must embed the detected model so reports across
+    the same relay become distinct indexable pages."""
+    meta = _seo_meta_for_report(_base_report())
+    title = meta["seo_title"]
+
+    assert "www.fucheers.top" in title
+    assert "OpenAI" in title
+    assert "gpt-5.5" in title, f"model missing from title: {title!r}"
+    assert "91/100" in title
+    assert "存在风险" in title
+
+
+def test_seo_title_falls_back_when_target_model_missing():
+    """Legacy reports / probe failures may not have target_model. Title
+    must still render coherently — must NOT print empty 'OpenAI 中转站  检测:'."""
+    meta = _seo_meta_for_report(_base_report(target_model=""))
+    title = meta["seo_title"]
+
+    # No leading/trailing extra space, no "  " (double space) artifact
+    assert "  " not in title, f"double-space artifact in fallback title: {title!r}"
+    assert "www.fucheers.top" in title
+    assert "OpenAI 中转站检测" in title
+    assert "91/100" in title
+
+
+def test_seo_title_distinct_per_model_same_relay():
+    """Regression for the long-tail SEO intent: same domain + same score
+    + different model should yield different titles (otherwise Google
+    de-duplicates them and we lose the indexable surface)."""
+    a = _seo_meta_for_report(_base_report(target_model="gpt-5.5"))["seo_title"]
+    b = _seo_meta_for_report(_base_report(target_model="gpt-5.4-mini"))["seo_title"]
+    c = _seo_meta_for_report(_base_report(target_model="gpt-4o"))["seo_title"]
+
+    assert a != b != c
+    assert "gpt-5.5" in a
+    assert "gpt-5.4-mini" in b
+    assert "gpt-4o" in c
+
+
+def test_seo_title_respects_155_char_cap():
+    """The 155-char cap is a hard SEO ceiling — long model snapshot IDs
+    must not push the title over."""
+    meta = _seo_meta_for_report(_base_report(target_model="gpt-5.5-2026-04-23"))
+    assert len(meta["seo_title"]) <= 155
+    assert "gpt-5.5-2026-04-23" in meta["seo_title"]
+
+
+def test_seo_description_still_mentions_model():
+    """The description block already mentioned model before this change —
+    guarding it here so a future title refactor doesn't accidentally drop
+    it from the meta description."""
+    meta = _seo_meta_for_report(_base_report(target_model="gpt-5.5"))
+    assert "gpt-5.5" in meta["seo_description"]

--- a/web/server.py
+++ b/web/server.py
@@ -591,9 +591,18 @@ def _seo_meta_for_report(report: dict) -> dict[str, str]:
     fail_count = sum(1 for r in results if isinstance(r, dict) and r.get("status") == "fail")
     total = len(results)
 
-    title = (
-        f"{domain} {proto_label} 中转站检测:{score:.0f}/100 {verdict_zh} | Veridrop"
-    )
+    # Title diversity drives long-tail SEO: each report becomes its own
+    # indexable page with a distinct query target ("X 站测 gpt-5.5 怎么样").
+    # Without the model, every report on the same domain shared one title.
+    if model:
+        title = (
+            f"{domain} {proto_label} 中转站 {model} 检测:"
+            f"{score:.0f}/100 {verdict_zh} | Veridrop"
+        )
+    else:
+        title = (
+            f"{domain} {proto_label} 中转站检测:{score:.0f}/100 {verdict_zh} | Veridrop"
+        )
     description = (
         f"对 {domain} 进行 {proto_label} 中转站检测的完整报告:"
         f"模型 {model},总分 {score:.0f}/100,判定为「{verdict_zh}」。"

--- a/web/templates/result.html
+++ b/web/templates/result.html
@@ -22,9 +22,12 @@
 {% endblock %}
 
 {% block content %}
-{# Breadcrumb: 首页 › 红黑榜 › {domain} › 报告 #{job_id}.
+{# Breadcrumb: 首页 › 红黑榜 › {domain} › {target_model}.
    When the report's base_url didn't yield a valid domain (legacy reports,
-   garbled URLs), drop the {domain} crumb and link straight to /leaderboard. #}
+   garbled URLs), drop the {domain} crumb and link straight to /leaderboard.
+   The trailing crumb shows the detected model so each report is uniquely
+   identifiable in nav and crawler-readable for long-tail SEO; falls back
+   to "报告 #{job_id}" when target_model is missing. #}
 <nav class="breadcrumb" aria-label="面包屑">
   <a href="/">首页</a>
   <span class="breadcrumb-sep">›</span>
@@ -34,7 +37,7 @@
     <a href="/leaderboard/{{ breadcrumb_domain }}">{{ breadcrumb_domain }}</a>
   {% endif %}
   <span class="breadcrumb-sep">›</span>
-  <span class="breadcrumb-current">报告 #{{ job_id }}</span>
+  <span class="breadcrumb-current">{% if report.target_model %}{{ report.target_model }}{% else %}报告 #{{ job_id }}{% endif %}</span>
 </nav>
 
 {% set perf = report.performance or {} %}


### PR DESCRIPTION
## 背景

每份 \`/r/{job_id}\` 报告页都是公开 indexable landing page,但当前同一中转站下所有报告共享一个 title:

> www.fucheers.top OpenAI 中转站检测:91/100 存在风险 | Veridrop

不同模型的报告(\`gpt-5.5\` / \`gpt-5.4-mini\` / \`gpt-4o\`)title 一字不差,Google 直接判定为重复页去重 → 长尾搜索(「XX 站测 gpt-5.5 怎么样」)全部 sink 到一个 canonical url,索引面塌成一份。

## 改动

### 1. Title 注入模型(\`web/server.py\` \`_seo_meta_for_report\`)

```diff
- {domain} {proto_label} 中转站检测:{score:.0f}/100 {verdict_zh} | Veridrop
+ {domain} {proto_label} 中转站 {model} 检测:{score:.0f}/100 {verdict_zh} | Veridrop
```

无 model 的边界情况(legacy 报告 / probe 失败)保留原模板,**避免出现 "中转站  检测" 双空格痕迹**。

### 2. 面包屑末尾段用模型名(\`web/templates/result.html\`)

```diff
- 首页 › 红黑榜 › www.fucheers.top › 报告 #MOd_d0vJ
+ 首页 › 红黑榜 › www.fucheers.top › gpt-5.5
```

没有 \`target_model\` 时仍回退到 \`报告 #{job_id}\`,跟旧报告兼容。

## 效果

- 每份报告 title 唯一,Google 视为独立 indexable page
- og:title 同步带 model,分享卡片直接展示测的是什么模型
- 面包屑跨报告导航时一眼看出模型,UX 也好

## 测试

\`tests/test_seo_meta.py\` 新增 5 个用例:

| 用例 | 断言 |
|---|---|
| \`test_seo_title_includes_target_model\` | 标题含 domain + protocol + model + 评分 + 判定 |
| \`test_seo_title_falls_back_when_target_model_missing\` | 空 model 不留双空格痕迹 |
| \`test_seo_title_distinct_per_model_same_relay\` | 同域名不同 model 三种 title 互不相同(SEO 反 dedupe 核心) |
| \`test_seo_title_respects_155_char_cap\` | 长 dated snapshot 不超 155 字符 |
| \`test_seo_description_still_mentions_model\` | description 仍提及 model(防回归) |

完整 248/248 通过。

## 部署

本 PR 跟 #1 互不冲突,合并顺序无所谓。